### PR TITLE
Don't cache build script output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "fd-lock",
  "serde",
  "serde_json",
 ]
@@ -223,6 +224,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "fd-lock"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,17 +265,17 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hope"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "cache-log",
  "chrono",
  "clap",
  "directories",
+ "fd-lock",
  "filetime",
  "serde",
  "serde_json",
- "tar",
  "tempfile",
 ]
 
@@ -463,17 +475,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
 ]
 
 [[package]]
@@ -727,14 +728,3 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "xattr"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
-dependencies = [
- "libc",
- "linux-raw-sys",
- "rustix",
-]

--- a/cache-log/Cargo.toml
+++ b/cache-log/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
+fd-lock = "4.0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/hope/Cargo.toml
+++ b/hope/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]
@@ -11,8 +11,8 @@ cache-log = { path = "../cache-log" }
 filetime = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tar = "0.4.41"
 directories = "5.0"
+tempfile = "3.10"
+fd-lock = "4.0.2"
 
 [dev-dependencies]
-tempfile = "3.10"


### PR DESCRIPTION
Instead skip building and running build scripts entirely if we know we can pull the final crate output, and just emit the build script's stdout from cache.

Note that this temporarily makes things slightly worse in some ways, in that Cargo will attempt to rebuild the build scripts over and over because it will _never_ find the files that have been emitted in "rerun-if-changed" directives. To deal with this, I'm intending to filter them out when we print stdout we got from the cache. But it's not totally now so I'm going to get this rework onto the main branch sooner rather than later.

https://github.com/jeffparsons/hope/issues/3