### PR TITLE
Second attempt at deferred build script execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "walkdir",
 ]
 
 [[package]]
@@ -430,6 +431,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +532,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +600,15 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "windows-core"

--- a/hope/Cargo.toml
+++ b/hope/Cargo.toml
@@ -14,5 +14,6 @@ serde_json = "1.0"
 directories = "5.0"
 tempfile = "3.10"
 fd-lock = "4.0.2"
+walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/hope/src/build_script.rs
+++ b/hope/src/build_script.rs
@@ -1,6 +1,9 @@
 //! Pretending to be a crate's build script
 
+use core::str;
 use std::{
+    collections::HashMap,
+    env,
     fs::File,
     io::Write,
     path::{Path, PathBuf},
@@ -11,34 +14,87 @@ use std::{
 use anyhow::Context;
 use cache_log::{write_log_line, BuildScriptRunEvent, CacheLogLine};
 use chrono::Utc;
+use serde::{Deserialize, Serialize};
 
 use crate::cache::{Cache, LocalCache};
 
-pub const BUILD_SCRIPT_CRATE_METADATA_HASH_FILE_NAME: &str =
-    "hope-build-script-crate-metadata-hash";
+pub const BUILD_SCRIPT_INVOCATION_INFO_FILE_NAME: &str = "build-script-invocation-info.json";
 
 pub fn run(called_as: &Path) -> anyhow::Result<()> {
+    // Figure out where the real build script is.
     let build_script_build_dir = called_as
         .parent()
         .context("Build script didn't have parent dir")?;
-    let (_, build_script_crate_metadata_hash) = build_script_build_dir
-        .to_str()
-        .context("Bad UTF-8 in build dir")?
-        .rsplit_once('-')
-        .with_context(|| {
-            format!(
-                "Build script build dir {:?} had unexpected format",
-                build_script_build_dir
-            )
-        })?;
-
     // TODO: See comments where this is created about wanting to not do "real-build-script" symlink.
     let real_build_script_symlink_path = build_script_build_dir.join("real-build-script");
-    if real_build_script_symlink_path.exists() {
-        // We previously created a symlink to the real build script,
-        // which we only do if we intend to run it.
-        //
-        // So... run the real build script.
+
+    // By convention, Cargo puts out dirs for build scripts under "target/debug/build/cratename-{metadata_hash}/out".
+    // (This is a private implementation detail, but in practice the Cargo maintainers have been very conservative
+    // about changing details like this, so it wouldn't be a big deal to adapt if they do occasionally change it.)
+    // We want the build script execution metadata hash.
+    let out_dir =
+        env::var("OUT_DIR").context("Missing 'OUT_DIR' env var for build script execution")?;
+    let out_dir =
+        PathBuf::from_str(&out_dir).context("'OUT_DIR' env var contained invalid path")?;
+    let (_, run_metadata_hash) = out_dir
+        .parent()
+        .context("Missing parent on out dir")?
+        .file_name()
+        .context("Missing file name on build dir")?
+        .to_str()
+        .context("Invalid UTF-8 in build dir name")?
+        .rsplit_once('-')
+        .context("Couldn't find '-' in build dir")?;
+
+    // Can we find the stdout of this build script execution in cache?
+    let cache = LocalCache::from_env()?;
+    if let Ok(build_script_stdout) = cache.get_build_script_stdout(run_metadata_hash) {
+        let build_script_stdout = str::from_utf8(&build_script_stdout)
+            .context("Cached build script output contained invalid UTF-8")?;
+        // We found the build script output in cache. We need to emit a copy of its output
+        // so that Cargo knows what flags to use when invoking `rustc` for building the main crate.
+        // (Most of them don't matter, but some things get a bit wonky if we don't emit the same thing
+        // that the real build script does.)
+        for line in build_script_stdout.lines() {
+            if line.starts_with("cargo:rerun-if-") {
+                // Skip output lines that would cause Cargo to consider
+                // the build script as dirty just because we don't actually run it.
+                //
+                // (We store the full output in the cache because it's easier for debugging
+                // and tweaking the rules here if we do it on the way _out_.)
+                continue;
+            }
+
+            // TODO: See if there are any lines in the stdout that need to have, e.g., paths mangled.
+
+            println!("{}", line);
+        }
+
+        // Don't bother printing the real stderr; it isn't used by Cargo.
+        // Instead, print something to help people if they end up debugging
+        // problems caused by Hope — just to hint at what's going on.
+        eprintln!("Fake build script by Hope; real build script not run because we intend to pull the main crate output from cache.");
+
+        // We also need to store some information about how this process was invoked so that
+        // we can run the real build script later just before building the main crate if we discover
+        // then that it's actually needed.
+        // (We don't want to run it if it turns out that the final crate output can be pulled from cache!)
+        let invocation_info = BuildScriptInvocationInfo {
+            real_build_script_path: real_build_script_symlink_path
+                .read_link()
+                .context("Failed to read symlink to real build script")?,
+            env_vars: env::vars().collect(),
+            work_dir: env::current_dir().context("Couldn't get working dir")?,
+        };
+        let invocation_info_file =
+            File::create(out_dir.join(BUILD_SCRIPT_INVOCATION_INFO_FILE_NAME))
+                .context("Failed to create build script invocation info file")?;
+        serde_json::to_writer(invocation_info_file, &invocation_info)
+            .context("Failed to write build script invocation info file")?;
+    } else {
+        // TODO: Care about the specific error.
+
+        // We couldn't find the build script output in cache, so we need to run it eagerly ourselves.
         let output = Command::new(&real_build_script_symlink_path)
             .output()
             .with_context(|| {
@@ -68,59 +124,11 @@ pub fn run(called_as: &Path) -> anyhow::Result<()> {
         std::io::stdout().write_all(&output.stdout)?;
         std::io::stdout().write_all(&output.stderr)?;
 
-        // And finally we need to leave a reference to the build script crate's
-        // metadata hash so that we can later detect that there's no need to build it!
-        // This will get pushed to the cache after the main crate build.
-        let out_dir = std::env::var("OUT_DIR").context("OUT_DIR env var not set")?;
-        let out_dir = PathBuf::from_str(&out_dir).context("Bad path in OUT_DIR env")?;
-        let build_dir = out_dir
-            .parent()
-            .context("Out dir missing parent directory")?;
-
-        let mut build_script_crate_metadata_hash_file =
-            File::create_new(build_dir.join(BUILD_SCRIPT_CRATE_METADATA_HASH_FILE_NAME))
-                .context("Failed to create file for build script crate metadata hash")?;
-        build_script_crate_metadata_hash_file
-            .write_all(build_script_crate_metadata_hash.as_bytes())?;
-
-        return Ok(());
+        // Finally, we need to store the build script output for other builds to find!
+        cache
+            .put_build_script_stdout(run_metadata_hash, &output.stdout)
+            .context("Failed to store build script output")?;
     }
-
-    // Try to get the real build script's stdout from cache.
-    //
-    // We have already verified at this point that we can find it,
-    // and have committed to _not_ building anything ourselves,
-    // so fail catastrophically if we can't get it.
-    let cache = LocalCache::from_env()?;
-    let build_script_stdout_bytes = cache
-        .get_build_script_stdout_by_build_script_crate_metadata_hash(
-            build_script_crate_metadata_hash,
-        )
-        .context("Failed to get build script stdout from cache")?;
-    let build_script_stdout = String::from_utf8(build_script_stdout_bytes)
-        .context("Build script output contained bad UTF-8")?;
-
-    // Print what we found to stdout to make Cargo invoke rustc with
-    // the right arguments for the real build. (Most of them don't matter,
-    // but some things get a bit wonky if we don't emit the same thing
-    // that the real build script does.)
-    for line in build_script_stdout.lines() {
-        if line.starts_with("cargo:rerun-if-") {
-            // Skip output lines that would cause Cargo to consider
-            // the build script as dirty just because we don't actually run it.
-            //
-            // (We store the full output in the cache because it's easier for debugging
-            // and tweaking the rules here if we do it on the way _out_.)
-            continue;
-        }
-
-        println!("{}", line);
-    }
-
-    // Don't bother printing the real stderr; it isn't used by Cargo.
-    // Instead, print something to help people if they end up debugging
-    // problems caused by Hope — just to hint at what's going on.
-    eprintln!("Fake build script by Hope; real build script not run because we intend to pull the main crate output from cache.");
 
     Ok(())
 }
@@ -132,4 +140,47 @@ pub fn append_moved_build_script_suffix(build_script_path: &Path) -> anyhow::Res
     let mut moved_build_script_file_name = build_script_file_name.to_owned();
     moved_build_script_file_name.push("-moved-by-hope");
     Ok(build_script_path.with_file_name(moved_build_script_file_name))
+}
+
+/// NOTE: We don't need to mangle anything here to tweak paths,
+/// because they are only used within the target directory
+/// of a single project — i.e. they don't get sent to the cache.
+///
+/// We don't bother storing command line arguments, because Cargo
+/// doesn't provide any to build script.
+#[derive(Serialize, Deserialize)]
+pub struct BuildScriptInvocationInfo {
+    pub real_build_script_path: PathBuf,
+    pub env_vars: HashMap<String, String>,
+    pub work_dir: PathBuf,
+}
+
+impl BuildScriptInvocationInfo {
+    /// Get the invoked timestamp for when Cargo originally
+    /// attempted to run the build script.
+    ///
+    /// See comments on `get_invoked_timestamp_for_crate_build_unit` for more detail.
+    pub fn get_invoked_timestamp(&self) -> anyhow::Result<filetime::FileTime> {
+        let out_dir = self.out_dir()?;
+        let build_script_invocation_build_dir = out_dir
+            .parent()
+            .context("Out dir missing parent; can't find invoked timestamp for build script run")?;
+        // Now read the mtime of the "invoked.timestamp" file for this build script execution unit.
+        let invoked_timestamp_path = build_script_invocation_build_dir.join("invoked.timestamp");
+        let invoked_timestamp_file_metadata = std::fs::metadata(invoked_timestamp_path).context(
+            "Failed to get metadata for \"invoked.timestamp\" file; maybe it doesn't exist?",
+        )?;
+        Ok(filetime::FileTime::from_last_modification_time(
+            &invoked_timestamp_file_metadata,
+        ))
+    }
+
+    pub fn out_dir(&self) -> anyhow::Result<PathBuf> {
+        let out_dir = self
+            .env_vars
+            .get("OUT_DIR")
+            .context("Missing 'OUT_DIR' env var in build script invocation info")?;
+        PathBuf::from_str(out_dir)
+            .context("Build script invocation info 'OUT_DIR' env var contained invalid path")
+    }
 }


### PR DESCRIPTION
Build scripts are replaced with a copy of Hope itself, which detects when it is invoked as a build script and only eagerly invokes the real build script if
absolutely necessary. (This is if we can't find stdout for a matching build script invocation in the cache.)

Then when Hope is invoked for building the main crate, iff we actually need to build the main crate then we will invoke the _real_ build script with the environment it was originally called with, and rewind timestamps of any files created to look like they were created when Cargo first thought it was running the build script.

There are some other details I haven't documented in this commit message, but in my (limited) testing it actually seems to work pretty well now!